### PR TITLE
Ignore default guard in favour of the first

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -46,6 +46,6 @@ class Guard
     {
         $default = config('auth.defaults.guard');
 
-        return static::getNames($class)->first() ?: $default;
+        return $default ?: static::getNames($class)->first();
     }
 }


### PR DESCRIPTION
Hi Guys.

We have a project with some subdomains, every subdomain has there own guard.

We also use the same views in more than one subdomain, so we only check the permission/role without the guard_name. In a middleware we change the **auth.defaults.guard** depending on the subdomain which is requested.

Im sure this is a bug, cause why would someone prefer the first guard in an list instead of the explicit defined default guard?
